### PR TITLE
Redirects to https://www.tissue-atlas.org

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,11 +1,11 @@
-<nav class="main-nav navbar navbar-expand-lg navbar-dark fixed-top bg-dark mb-md-4">
+<nav class="main-nav navbar navbar-expand-lg navbar-light fixed-top mb-md-4">
   <div class="container">
     <a class="navbar-brand" href="{{ site.baseurl }}/">
-      <strong>CyCIF</strong>
+      <img src="https://www.tissue-atlas.org/assets/img/logo-hta.svg" height="25"/>
     </a>
     <button class="navbar-toggler p-2" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault"
       aria-expanded="false" aria-label="Toggle navigation">
-      <span class="text-white">MENU</span>
+      <span class="text-black">MENU</span>
     </button>
     <div class="collapse navbar-collapse" id="navbarsExampleDefault">
       <ul class="navbar-nav mr-auto">
@@ -17,21 +17,6 @@
         </li>
         {% endfor %}
       </ul>
-          <div class="flex-row ml-md-auto">
-  
-            <a href="{{site.baseurl}}/featured-paper/du-lin-rashid-2019/figures/osd-LUNG_3" class="btn btn-outline-light font-weight-bold" style="font-size: 1rem; background: url({{ site.baseurl }}/assets/img/explore_button.jpg) center; background-size: cover;">
-              <span class="text-white">
-                  Explore CyCIF
-              </span> 
-            </a>
-          </div> 
     </div>
-  </div>
-</nav>
-<nav class="navbar navbar-expand-md navbar-dark bg-dark">
-  <div class="container">
-    <a class="navbar-brand" href="#">
-      <strong>CyCIF</strong>
-    </a>
   </div>
 </nav>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}"> {% seo %}
   <link rel="stylesheet" href="{{ '/assets/css/select2.min.css' | relative_url }}">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"></script>
   
   {% if site.google_analytics %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -26,6 +26,24 @@ svg a:hover text {
   fill: #0fabff;
 }
 
+.navbar-light {
+  font-family: 'Roboto', sans-serif;
+  background-color: rgba(255, 255, 255, 0.86);
+}
+.navbar-light .navbar-nav > .nav-item > .nav-link {
+  color: #0a59a8;
+}
+
+.navbar-light .container > .navbar-toggler {
+  border-color: rgba(0, 0, 0, 0.86);
+  grid-template-rows: 0.2em auto 1fr;
+}
+.navbar-light .container > .navbar-toggler > span {
+  margin-top: 0.15em;
+  display: block;
+}
+
+
 .banner-text-container,
 .banner-tall {
   background-color: rgba(0, 0, 0, 0.3);

--- a/data/index.html
+++ b/data/index.html
@@ -1,6 +1,8 @@
 ---
 title: Data
 layout: data
+redirect_to:
+  - http://tissue-atlas.org/data-overview
 ---
 <h2 class="h2">
   Visualizing and sharing multiplexed CyCIF data

--- a/funding/index.md
+++ b/funding/index.md
@@ -1,5 +1,7 @@
 ---
 title: Funding
+redirect_to:
+  - http://tissue-atlas.org/funding
 grants: 
     - name: Center for Pre-cancer Atlases of Cutaneous and Hematologic Origin (PATCH)
       link: patch

--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 ---
 redirect_from: /pca2018/
+redirect_to:
+  - http://tissue-atlas.org
 active: home
 title: CyCIF - Cyclic Immunofluorescence
 ---

--- a/people.md
+++ b/people.md
@@ -1,5 +1,7 @@
 ---
 title: People
+redirect_to:
+  - http://tissue-atlas.org/people
 ---
 
 

--- a/publications.md
+++ b/publications.md
@@ -1,5 +1,7 @@
 ---
 title: Publications
+redirect_to:
+  - http://tissue-atlas.org/publications
 ---
 
 ## Our Publications

--- a/software/index.md
+++ b/software/index.md
@@ -1,5 +1,7 @@
 ---
 title: Software
+redirect_to:
+  - http://tissue-atlas.org/software
 ---
 ## Software solutions for CyCIF and beyond
 We develop opensource software to tackle common challenges imposed by the highly-multiplexed whole slide imaging.


### PR DESCRIPTION
[redirects.webm](https://github.com/labsyspharm/cycif.org/assets/9781588/83a3f1bd-29d4-4974-8b79-1d628fc742f3)

The above video shows how a story on https://www.tissue-atlas.org will be redirected to a Minerva Story on cycif.org, but with a new Harvard Tissue Atlas navigation bar, demonstrating a subset of redirected navigation items. The CyCIF.org homepage, Software, Publications, People, Funding, and Data pages are redirected to the Harvard Tissue Atlas. 

The logos on the left side of the video represent the domain name in the URL at any given time, and the orange "rewind" arrow represents the browser back button. The browser URL is omitted from the video, as this test is run locally.