### PR TITLE
Remove deprecated Jekyll deployment workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -42,6 +42,7 @@ jobs:
   deploy-pages:
     permissions:
       id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -34,10 +34,9 @@ jobs:
           gem install bundler jekyll
           bundle install
           bundle exec jekyll build  --baseurl "${{ steps.pages.outputs.base_path }}" --destination _site
+          ls -lha _site
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v2
-        with:
-          path: './_site/*'
 
   # Deployment job
   deploy-pages:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           gem install bundler jekyll
           bundle install
-          bundle exec jekyll build  --baseurl "${{ steps.pages.outputs.base_path }}"
+          bundle exec jekyll build  --baseurl "${{ steps.pages.outputs.base_path }}" --destination _site
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v2
         with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  github-pages:
+  build-pages:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,14 +26,28 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
       - name: Build Jekyll site
         run: |
           gem install bundler jekyll
           bundle install
-          bundle exec jekyll build
+          bundle exec jekyll build  --baseurl "${{ steps.pages.outputs.base_path }}"
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v2
         with:
           path: './_site/*'
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
+
+    # Deployment job
+    deploy-pages:
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+      runs-on: ubuntu-latest
+      needs: build-pages
+      steps:
+        - name: Deploy to GitHub Pages
+          id: deployment
+          uses: actions/deploy-pages@v2
+

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Build with Webpack
         run: |
           ./node_modules/.bin/webpack --mode production
-      - uses: helaili/jekyll-action@2.0.1
-        env:
-          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Build Jekyll site
+        run: |
+          gem install bundler jekyll
+          bundle install
+          bundle exec jekyll build
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: './_site/*'
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -40,6 +40,8 @@ jobs:
 
   # Deployment job
   deploy-pages:
+    permissions:
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.0
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,15 +39,15 @@ jobs:
         with:
           path: './_site/*'
 
-    # Deployment job
-    deploy-pages:
-      environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
-      runs-on: ubuntu-latest
-      needs: build-pages
-      steps:
-        - name: Deploy to GitHub Pages
-          id: deployment
-          uses: actions/deploy-pages@v2
+  # Deployment job
+  deploy-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-pages
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
 


### PR DESCRIPTION
Using newer Jekyll build process to avoid need for `gh-pages` branch.